### PR TITLE
Generic chef strat script (used for rest of sushi vaults)

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@openzeppelin-2/contracts": "npm:@openzeppelin/contracts@2.5.1",
     "@openzeppelin/contracts": "^3.2.0",
     "bignumber.js": "^9.0.1",
+    "blockchain-addressbook": "^0.1.17",
     "keccak": "^3.0.1",
     "rlp": "^2.2.6"
   },

--- a/scripts/deploy-generic-chef-strat.js
+++ b/scripts/deploy-generic-chef-strat.js
@@ -1,0 +1,86 @@
+const hardhat = require("hardhat");
+
+// const registerSubsidy = require("../utils/registerSubsidy");
+const predictAddresses = require("../utils/predictAddresses");
+const getNetworkRpc = require("../utils/getNetworkRpc");
+const { addressBook } = require("blockchain-addressbook")
+const { DAI: { address: DAI }, USDC: { address: USDC }, ETH: { address: ETH }, WMATIC: { address: WMATIC }, SUSHI: { address: SUSHI } } = addressBook.polygon.tokens;
+const { sushi, beefyfinance } = addressBook.polygon.platforms;
+
+const ethers = hardhat.ethers;
+
+const vaultParams = {
+  mooName: "Moo Sushi USDC-DAI",
+  mooSymbol: "mooSushiUSDC-DAI",
+  delay: 21600,
+}
+
+const strategyParams = {
+  want: "0xcd578f016888b57f1b1e3f887f392f0159e26747",
+  poolId: 11,
+  chef: sushi.minichef,
+  unirouter: sushi.router,
+  strategist: "0x4e3227c0b032161Dd6D780E191A590D917998Dc7", // some address
+  keeper: beefyfinance.keeper,
+  beefyFeeRecipient: beefyfinance.beefyFeeRecipient,
+  outputToNativeRoute: [ SUSHI, WMATIC ],
+  outputToLp0Route: [ SUSHI, ETH, USDC ],
+  outputToLp1Route: [ SUSHI, ETH, DAI ]
+};
+
+const contractNames = {
+  vault: "BeefyVaultV6",
+  strategy: "StrategyPolygonSushiLP"
+}
+
+async function main() {
+  if (Object.values(vaultParams).some((v) => v === undefined) || Object.values(strategyParams).some((v) => v === undefined) || Object.values(contractNames).some((v) => v === undefined)) {
+    console.error("one of config values undefined");
+    return;
+  }
+
+  await hardhat.run("compile");
+
+  const Vault = await ethers.getContractFactory(contractNames.vault);
+  const Strategy = await ethers.getContractFactory(contractNames.strategy);
+
+  const [deployer] = await ethers.getSigners();
+  const rpc = getNetworkRpc(hardhat.network.name);
+
+  console.log("Deploying:", vaultParams.mooName);
+
+  const predictedAddresses = await predictAddresses({ creator: deployer.address, rpc });
+
+  const vault = await Vault.deploy(predictedAddresses.strategy, vaultParams.mooName, vaultParams.mooSymbol, vaultParams.delay);
+  await vault.deployed();
+
+  const strategy = await Strategy.deploy(
+    strategyParams.want,
+    strategyParams.poolId,
+    strategyParams.chef,
+    vault.address,
+    strategyParams.unirouter,
+    strategyParams.keeper,
+    strategyParams.strategist,
+    strategyParams.beefyFeeRecipient,
+    strategyParams.outputToNativeRoute,
+    strategyParams.outputToLp0Route,
+    strategyParams.outputToLp1Route
+  );
+  await strategy.deployed();
+
+  console.log("Vault deployed to:", vault.address);
+  console.log("Strategy deployed to:", strategy.address);
+
+  // if (hardhat.network.name === "bsc") {
+  //   await registerSubsidy(vault.address, deployer);
+  //   await registerSubsidy(strategy.address, deployer);
+  // }
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1671,6 +1671,11 @@ blakejs@^1.1.0:
   resolved "https://registry.yarnpkg.com/blakejs/-/blakejs-1.1.0.tgz#69df92ef953aa88ca51a32df6ab1c54a155fc7a5"
   integrity sha1-ad+S75U6qIylGjLfarHFShVfx6U=
 
+blockchain-addressbook@^0.1.17:
+  version "0.1.17"
+  resolved "https://registry.yarnpkg.com/blockchain-addressbook/-/blockchain-addressbook-0.1.17.tgz#0dc2c9977bd7a036575fa1c3b75e394b8e6f26ed"
+  integrity sha512-3j7b0TB2GIIVAhLsspUyE1Wkq7UmW4ufOmNCMEXsaBb6cGF/1zIY1bvRBDdYGileO9W/JvBA9mogLHTAtG+AZA==
+
 bluebird@^3.5.0, bluebird@^3.5.2:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"


### PR DESCRIPTION
Added a script for generic chef pools and changed sushi contract where OutputToLp0, OutputToLp1, outputToNative are now inputs. using blockchain-addressbook package as inputs to the config.