### PR TITLE
Pancakeswap optimised bnb lps strategy

### DIFF
--- a/contracts/BIFI/strategies/Cake/StrategyCakeWbnbLP.sol
+++ b/contracts/BIFI/strategies/Cake/StrategyCakeWbnbLP.sol
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.6.0;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
+import "@openzeppelin/contracts/math/SafeMath.sol";
+
+import "../../interfaces/common/IUniswapRouterETH.sol";
+import "../../interfaces/common/IUniswapV2Pair.sol";
+import "../../interfaces/pancake/IMasterChef.sol";
+import "../../utils/GasThrottler.sol";
+import "../Common/StratManager.sol";
+import "../Common/FeeManager.sol";
+
+contract StrategyCakeWbnbLP is StratManager, FeeManager, GasThrottler {
+    using SafeERC20 for IERC20;
+    using SafeMath for uint256;
+
+    // Tokens used
+    address constant public wbnb = address(0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c);
+    address constant public cake = address(0x0E09FaBB73Bd3Ade0a17ECC321fD13a19e81cE82);
+    address public want;
+    address public lpToken0;
+    address public lpToken1;
+
+    // Third party contracts
+    address constant public masterchef = address(0x73feaa1eE314F8c655E354234017bE2193C9E24E);
+    uint256 public poolId;
+
+    // Routes
+    address[] public cakeToWbnbRoute = [cake, wbnb];
+    address[] public wbnbToLp0Route;
+    address[] public wbnbToLp1Route;
+
+    /**
+     * @dev Event that is fired each time someone harvests the strat.
+     */
+    event StratHarvest(address indexed harvester);
+
+    constructor(
+        address _want,
+        uint256 _poolId,
+        address _vault,
+        address _unirouter,
+        address _keeper,
+        address _strategist,
+        address _beefyFeeRecipient
+    ) StratManager(_keeper, _strategist, _unirouter, _vault, _beefyFeeRecipient) public {
+        want = _want;
+        lpToken0 = IUniswapV2Pair(want).token0();
+        lpToken1 = IUniswapV2Pair(want).token1();
+        poolId = _poolId;
+
+        if (lpToken0 != wbnb) {
+            wbnbToLp0Route = [wbnb, lpToken0];
+        }
+
+        if (lpToken1 != wbnb) {
+            wbnbToLp1Route = [wbnb, lpToken1];
+        }
+
+        _giveAllowances();
+    }
+
+    // puts the funds to work
+    function deposit() public whenNotPaused {
+        uint256 wantBal = IERC20(want).balanceOf(address(this));
+
+        if (wantBal > 0) {
+            IMasterChef(masterchef).deposit(poolId, wantBal);
+        }
+    }
+
+    function withdraw(uint256 _amount) external {
+        require(msg.sender == vault, "!vault");
+
+        uint256 wantBal = IERC20(want).balanceOf(address(this));
+
+        if (wantBal < _amount) {
+            IMasterChef(masterchef).withdraw(poolId, _amount.sub(wantBal));
+            wantBal = IERC20(want).balanceOf(address(this));
+        }
+
+        if (wantBal > _amount) {
+            wantBal = _amount;
+        }
+
+        if (tx.origin == owner() || paused()) {
+            IERC20(want).safeTransfer(vault, wantBal);
+        } else {
+            uint256 withdrawalFeeAmount = wantBal.mul(withdrawalFee).div(WITHDRAWAL_MAX);
+            IERC20(want).safeTransfer(vault, wantBal.sub(withdrawalFeeAmount));
+        }
+    }
+
+    // compounds earnings and charges performance fee
+    function harvest() external whenNotPaused onlyEOA gasThrottle {
+        IMasterChef(masterchef).deposit(poolId, 0);
+
+        uint256 toWbnb = IERC20(cake).balanceOf(address(this));
+        IUniswapRouterETH(unirouter).swapExactTokensForTokens(toWbnb, 0, cakeToWbnbRoute, address(this), now);
+
+        chargeFees();
+        addLiquidity();
+        deposit();
+
+        emit StratHarvest(msg.sender);
+    }
+
+    // performance fees
+    function chargeFees() internal {
+        uint256 wbnbFees = IERC20(wbnb).balanceOf(address(this)).mul(45).div(1000);
+
+        uint256 callFeeAmount = wbnbFees.mul(callFee).div(MAX_FEE);
+        IERC20(wbnb).safeTransfer(msg.sender, callFeeAmount);
+
+        uint256 beefyFeeAmount = wbnbFees.mul(beefyFee).div(MAX_FEE);
+        IERC20(wbnb).safeTransfer(beefyFeeRecipient, beefyFeeAmount);
+
+        uint256 strategistFee = wbnbFees.mul(STRATEGIST_FEE).div(MAX_FEE);
+        IERC20(wbnb).safeTransfer(strategist, strategistFee);
+    }
+
+    // Adds liquidity to AMM and gets more LP tokens.
+    function addLiquidity() internal {
+        uint256 wbnbHalf = IERC20(wbnb).balanceOf(address(this)).div(2);
+
+        if (lpToken0 != wbnb) {
+            IUniswapRouterETH(unirouter).swapExactTokensForTokens(wbnbHalf, 0, wbnbToLp0Route, address(this), now);
+        }
+
+        if (lpToken1 != wbnb) {
+            IUniswapRouterETH(unirouter).swapExactTokensForTokens(wbnbHalf, 0, wbnbToLp1Route, address(this), now);
+        }
+
+        uint256 lp0Bal = IERC20(lpToken0).balanceOf(address(this));
+        uint256 lp1Bal = IERC20(lpToken1).balanceOf(address(this));
+        IUniswapRouterETH(unirouter).addLiquidity(lpToken0, lpToken1, lp0Bal, lp1Bal, 1, 1, address(this), now);
+    }
+
+    // calculate the total underlaying 'want' held by the strat.
+    function balanceOf() public view returns (uint256) {
+        return balanceOfWant().add(balanceOfPool());
+    }
+
+    // it calculates how much 'want' this contract holds.
+    function balanceOfWant() public view returns (uint256) {
+        return IERC20(want).balanceOf(address(this));
+    }
+
+    // it calculates how much 'want' the strategy has working in the farm.
+    function balanceOfPool() public view returns (uint256) {
+        (uint256 _amount, ) = IMasterChef(masterchef).userInfo(poolId, address(this));
+        return _amount;
+    }
+
+    // called as part of strat migration. Sends all the available funds back to the vault.
+    function retireStrat() external {
+        require(msg.sender == vault, "!vault");
+
+        IMasterChef(masterchef).emergencyWithdraw(poolId);
+
+        uint256 wantBal = IERC20(want).balanceOf(address(this));
+        IERC20(want).transfer(vault, wantBal);
+    }
+
+    // pauses deposits and withdraws all funds from third party systems.
+    function panic() public onlyManager {
+        pause();
+        IMasterChef(masterchef).emergencyWithdraw(poolId);
+    }
+
+    function pause() public onlyManager {
+        _pause();
+
+        _removeAllowances();
+    }
+
+    function unpause() external onlyManager {
+        _unpause();
+
+        _giveAllowances();
+
+        deposit();
+    }
+
+    function _giveAllowances() internal {
+        IERC20(want).safeApprove(masterchef, uint256(-1));
+        IERC20(cake).safeApprove(unirouter, uint256(-1));
+        IERC20(wbnb).safeApprove(unirouter, uint256(-1));
+
+        IERC20(lpToken0).safeApprove(unirouter, 0);
+        IERC20(lpToken0).safeApprove(unirouter, uint256(-1));
+
+        IERC20(lpToken1).safeApprove(unirouter, 0);
+        IERC20(lpToken1).safeApprove(unirouter, uint256(-1));
+    }
+
+    function _removeAllowances() internal {
+        IERC20(want).safeApprove(masterchef, 0);
+        IERC20(cake).safeApprove(unirouter, 0);
+        IERC20(wbnb).safeApprove(unirouter, 0);
+        IERC20(lpToken0).safeApprove(unirouter, 0);
+        IERC20(lpToken1).safeApprove(unirouter, 0);
+    }
+}


### PR DESCRIPTION
Optimises strategy for BNB lps where lp0 and lp1 are not Cake. Also applicable for non-BNB lps if enough liquidity

Logic:
1. Swap all to WBNB
2. Take fees from WBNB without swaps
3. Continue to swap WBNB for lp0 and lp1