### PR TITLE
Allow to define the most efficient swap path

### DIFF
--- a/contracts/BIFI/strategies/Cake/StrategyCakeRoutableLP.sol
+++ b/contracts/BIFI/strategies/Cake/StrategyCakeRoutableLP.sol
@@ -1,0 +1,206 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.6.0;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
+import "@openzeppelin/contracts/math/SafeMath.sol";
+
+import "../../interfaces/common/IUniswapRouterETH.sol";
+import "../../interfaces/common/IUniswapV2Pair.sol";
+import "../../interfaces/pancake/IMasterChef.sol";
+import "../../utils/GasThrottler.sol";
+import "../Common/StratManager.sol";
+import "../Common/FeeManager.sol";
+
+contract StrategyCakeRoutableLP is StratManager, FeeManager, GasThrottler {
+    using SafeERC20 for IERC20;
+    using SafeMath for uint256;
+
+    // Tokens used
+    address constant public wbnb = address(0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c);
+    address constant public cake = address(0x0E09FaBB73Bd3Ade0a17ECC321fD13a19e81cE82);
+    address public want;
+    address public lpToken0;
+    address public lpToken1;
+
+    // Third party contracts
+    address constant public masterchef = address(0x73feaa1eE314F8c655E354234017bE2193C9E24E);
+    uint256 immutable public poolId;
+
+    // Routes
+    address[] public cakeToWbnbRoute = [cake, wbnb];
+    address[] public cakeToLp0Route;
+    address[] public cakeToLp1Route;
+
+    /**
+     * @dev Event that is fired each time someone harvests the strat.
+     */
+    event StratHarvest(address indexed harvester);
+
+    constructor(
+        address _want,
+        uint256 _poolId,
+        address _vault,
+        address _unirouter,
+        address _keeper,
+        address _strategist,
+        address _beefyFeeRecipient,
+        address[] memory _cakeToLp0Route,
+        address[] memory _cakeToLp1Route
+    ) StratManager(_keeper, _strategist, _unirouter, _vault, _beefyFeeRecipient) public {
+        want = _want;
+        lpToken0 = IUniswapV2Pair(want).token0();
+        lpToken1 = IUniswapV2Pair(want).token1();
+        poolId = _poolId;
+
+        if (lpToken0 != cake) {
+            cakeToLp0Route = _cakeToLp0Route;
+        }
+
+        if (lpToken1 != cake) {
+            cakeToLp1Route = _cakeToLp1Route;
+        }
+
+        _giveAllowances();
+    }
+
+    // puts the funds to work
+    function deposit() public whenNotPaused {
+        uint256 wantBal = IERC20(want).balanceOf(address(this));
+
+        if (wantBal > 0) {
+            IMasterChef(masterchef).deposit(poolId, wantBal);
+        }
+    }
+
+    function withdraw(uint256 _amount) external {
+        require(msg.sender == vault, "!vault");
+
+        uint256 wantBal = IERC20(want).balanceOf(address(this));
+
+        if (wantBal < _amount) {
+            IMasterChef(masterchef).withdraw(poolId, _amount.sub(wantBal));
+            wantBal = IERC20(want).balanceOf(address(this));
+        }
+
+        if (wantBal > _amount) {
+            wantBal = _amount;
+        }
+
+        if (tx.origin == owner() || paused()) {
+            IERC20(want).safeTransfer(vault, wantBal);
+        } else {
+            uint256 withdrawalFeeAmount = wantBal.mul(withdrawalFee).div(WITHDRAWAL_MAX);
+            IERC20(want).safeTransfer(vault, wantBal.sub(withdrawalFeeAmount));
+        }
+    }
+
+    // compounds earnings and charges performance fee
+    function harvest() external whenNotPaused onlyEOA gasThrottle {
+        IMasterChef(masterchef).deposit(poolId, 0);
+        chargeFees();
+        addLiquidity();
+        deposit();
+
+        emit StratHarvest(msg.sender);
+    }
+
+    // performance fees
+    function chargeFees() internal {
+        uint256 toWbnb = IERC20(cake).balanceOf(address(this)).mul(45).div(1000);
+        IUniswapRouterETH(unirouter).swapExactTokensForTokens(toWbnb, 0, cakeToWbnbRoute, address(this), now);
+
+        uint256 wbnbBal = IERC20(wbnb).balanceOf(address(this));
+
+        uint256 callFeeAmount = wbnbBal.mul(callFee).div(MAX_FEE);
+        IERC20(wbnb).safeTransfer(msg.sender, callFeeAmount);
+
+        uint256 beefyFeeAmount = wbnbBal.mul(beefyFee).div(MAX_FEE);
+        IERC20(wbnb).safeTransfer(beefyFeeRecipient, beefyFeeAmount);
+
+        uint256 strategistFee = wbnbBal.mul(STRATEGIST_FEE).div(MAX_FEE);
+        IERC20(wbnb).safeTransfer(strategist, strategistFee);
+    }
+
+    // Adds liquidity to AMM and gets more LP tokens.
+    function addLiquidity() internal {
+        uint256 cakeHalf = IERC20(cake).balanceOf(address(this)).div(2);
+
+        if (lpToken0 != cake) {
+            IUniswapRouterETH(unirouter).swapExactTokensForTokens(cakeHalf, 0, cakeToLp0Route, address(this), now);
+        }
+
+        if (lpToken1 != cake) {
+            IUniswapRouterETH(unirouter).swapExactTokensForTokens(cakeHalf, 0, cakeToLp1Route, address(this), now);
+        }
+
+        uint256 lp0Bal = IERC20(lpToken0).balanceOf(address(this));
+        uint256 lp1Bal = IERC20(lpToken1).balanceOf(address(this));
+        IUniswapRouterETH(unirouter).addLiquidity(lpToken0, lpToken1, lp0Bal, lp1Bal, 1, 1, address(this), now);
+    }
+
+    // calculate the total underlaying 'want' held by the strat.
+    function balanceOf() public view returns (uint256) {
+        return balanceOfWant().add(balanceOfPool());
+    }
+
+    // it calculates how much 'want' this contract holds.
+    function balanceOfWant() public view returns (uint256) {
+        return IERC20(want).balanceOf(address(this));
+    }
+
+    // it calculates how much 'want' the strategy has working in the farm.
+    function balanceOfPool() public view returns (uint256) {
+        (uint256 _amount, ) = IMasterChef(masterchef).userInfo(poolId, address(this));
+        return _amount;
+    }
+
+    // called as part of strat migration. Sends all the available funds back to the vault.
+    function retireStrat() external {
+        require(msg.sender == vault, "!vault");
+
+        IMasterChef(masterchef).emergencyWithdraw(poolId);
+
+        uint256 wantBal = IERC20(want).balanceOf(address(this));
+        IERC20(want).transfer(vault, wantBal);
+    }
+
+    // pauses deposits and withdraws all funds from third party systems.
+    function panic() public onlyManager {
+        pause();
+        IMasterChef(masterchef).emergencyWithdraw(poolId);
+    }
+
+    function pause() public onlyManager {
+        _pause();
+
+        _removeAllowances();
+    }
+
+    function unpause() external onlyManager {
+        _unpause();
+
+        _giveAllowances();
+
+        deposit();
+    }
+
+    function _giveAllowances() internal {
+        IERC20(want).safeApprove(masterchef, uint256(-1));
+        IERC20(cake).safeApprove(unirouter, uint256(-1));
+
+        IERC20(lpToken0).safeApprove(unirouter, 0);
+        IERC20(lpToken0).safeApprove(unirouter, uint256(-1));
+
+        IERC20(lpToken1).safeApprove(unirouter, 0);
+        IERC20(lpToken1).safeApprove(unirouter, uint256(-1));
+    }
+
+    function _removeAllowances() internal {
+        IERC20(want).safeApprove(masterchef, 0);
+        IERC20(cake).safeApprove(unirouter, 0);
+        IERC20(lpToken0).safeApprove(unirouter, 0);
+        IERC20(lpToken1).safeApprove(unirouter, 0);
+    }
+}

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "all": "yarn clean && yarn compile && yarn net",
     "test": "hardhat test --network localhost",
     "deploy-strat:bsc": "hardhat run --network bsc scripts/deploy-strat-with-pool.js",
+    "deploy-strat:bsc:pancake": "hardhat run --network bsc scripts/pancake-deploy-strat-with-pool.js",
     "deploy-strat:lendhub": "hardhat run --network heco scripts/deploy-strat-lendhub.js",
     "deploy-strat:polygon": "hardhat run --network polygon scripts/deploy-strat-with-pool.js",
     "deploy-pool:bsc": "hardhat run --network bsc scripts/deploy-launchpad-pool.js",

--- a/scripts/pancake-deploy-strat-with-pool.js
+++ b/scripts/pancake-deploy-strat-with-pool.js
@@ -1,0 +1,76 @@
+const hardhat = require("hardhat");
+
+const registerSubsidy = require("../utils/registerSubsidy");
+const predictAddresses = require("../utils/predictAddresses");
+const getNetworkRpc = require("../utils/getNetworkRpc");
+
+const ethers = hardhat.ethers;
+
+const cake = "0x0E09FaBB73Bd3Ade0a17ECC321fD13a19e81cE82";
+const wbnb = "0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c";
+const busd = "0xe9e7cea3dedca5984780bafc599bd69add087d56";
+const usdc = "0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d";
+const eth = "0x2170Ed0880ac9A755fd29B2688956BD959F933F8";
+
+const config = {
+  want: "0xEa26B78255Df2bBC31C1eBf60010D78670185bD0",
+  mooName: "Moo CakeV2 ETH-USDC",
+  mooSymbol: "mooCakeV2ETH-USDC",
+  delay: 21600,
+  strategyName: "StrategyCakeRoutableLP",
+  poolId: 409,
+  unirouter: "0x10ED43C718714eb63d5aA57B78B54704E256024E", // Pancakeswap Router V2
+  strategist: "0xEB41298BA4Ea3865c33bDE8f60eC414421050d53", // your address for rewards
+  keeper: "0xd529b1894491a0a26B18939274ae8ede93E81dbA",
+  beefyFeeRecipient: "0xEB41298BA4Ea3865c33bDE8f60eC414421050d53",
+  cakeToLp0Route: [ cake, wbnb, eth ],
+  cakeToLp1Route: [ cake, busd, usdc ],
+};
+
+async function main() {
+  if (Object.values(config).some((v) => v === undefined)) {
+    console.error("one of config values undefined");
+    return;
+  }
+
+  await hardhat.run("compile");
+
+  const Vault = await ethers.getContractFactory("BeefyVaultV6");
+  const Strategy = await ethers.getContractFactory(config.strategyName);
+
+  const [deployer] = await ethers.getSigners();
+  const rpc = getNetworkRpc(hardhat.network.name);
+
+  console.log("Deploying:", config.mooName);
+
+  const predictedAddresses = await predictAddresses({ creator: deployer.address, rpc });
+
+  const vault = await Vault.deploy(predictedAddresses.strategy, config.mooName, config.mooSymbol, config.delay);
+  await vault.deployed();
+
+  const strategy = await Strategy.deploy(
+    config.want,
+    config.poolId,
+    vault.address,
+    config.unirouter,
+    config.keeper,
+    config.strategist,
+    config.beefyFeeRecipient,
+    config.cakeToLp0Route,
+    config.cakeToLp1Route,
+  );
+  await strategy.deployed();
+
+  console.log("Vault deployed to:", vault.address);
+  console.log("Strategy deployed to:", strategy.address);
+
+  await registerSubsidy(vault.address, deployer);
+  await registerSubsidy(strategy.address, deployer);
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });


### PR DESCRIPTION
Tiny step towards industrialisation for cake lp farms:

 - Allow to specify custom swap paths on deployment
 - Used in mooCakeV2ETH-USDC strategy https://github.com/beefyfinance/beefy-app/pull/537

Unlocks next step:

- Automated selection of most efficient swap path on deployment