### PR TITLE
Update PangolinV2 contract

### DIFF
--- a/contracts/BIFI/interfaces/pangolin/IPangolinRewarder.sol
+++ b/contracts/BIFI/interfaces/pangolin/IPangolinRewarder.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.6.12;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+interface IPangolinRewarder {
+    function pendingTokens(uint256 _pid, address _user, uint256 _rewardAmount) external view returns (IERC20[] memory tokens, uint256[] memory amounts);
+} 

--- a/contracts/BIFI/strategies/Pangolin/StrategyPangolinMiniChefLP.sol
+++ b/contracts/BIFI/strategies/Pangolin/StrategyPangolinMiniChefLP.sol
@@ -64,7 +64,6 @@ contract StrategyPangolinMiniChefLP is StratManager, FeeManager {
         poolId = _poolId;
         chef = _chef;
 
-        require(_outputToNativeRoute.length >= 2);
         output = _outputToNativeRoute[0];
         native = _outputToNativeRoute[_outputToNativeRoute.length - 1];
         outputToNativeRoute = _outputToNativeRoute;
@@ -228,10 +227,12 @@ contract StrategyPangolinMiniChefLP is StratManager, FeeManager {
     // returns secondary rewards unharvested
     function secondaryRewardsAvailable() public view returns (uint256[] memory) {
         address rewarder = IPangolinMiniChef(chef).rewarder(poolId);
-        require(rewarder != nullAddress, "rewarder == nullAddress");
+        // checks if there is a rewarder associated with the pool, if not will return an empty array.
+        if (rewarder != nullAddress) {
         uint256 pngReward = rewardsAvailable();
         (, uint256[] memory amounts) = IPangolinRewarder(rewarder).pendingTokens(poolId, address(this), pngReward);
         return amounts;
+        }
     }
 
     function callReward() public view returns (uint256) {

--- a/contracts/BIFI/strategies/Pangolin/StrategyPangolinMiniChefLP.sol
+++ b/contracts/BIFI/strategies/Pangolin/StrategyPangolinMiniChefLP.sol
@@ -147,11 +147,11 @@ contract StrategyPangolinMiniChefLP is StratManager, FeeManager {
     function _harvest(address callFeeRecipient) internal whenNotPaused {
         IPangolinMiniChef(chef).harvest(poolId, address(this));
         if (rewardToOutputRoute[0] != nullAddress) {
-                address reward = rewardToOutputRoute[0];
-                uint256 rewardBal = IERC20(reward).balanceOf(address(this));
-                if (rewardBal > 0) {
-                    IUniswapRouterETH(unirouter).swapExactTokensForTokens(rewardBal, 0, rewardToOutputRoute, address(this), now);
-                }
+            address reward = rewardToOutputRoute[0];
+            uint256 rewardBal = IERC20(reward).balanceOf(address(this));
+            if (rewardBal > 0) {
+                IUniswapRouterETH(unirouter).swapExactTokensForTokens(rewardBal, 0, rewardToOutputRoute, address(this), now);
+            }
         }
 
         uint256 outputBal = IERC20(output).balanceOf(address(this));
@@ -295,8 +295,8 @@ contract StrategyPangolinMiniChefLP is StratManager, FeeManager {
         IERC20(lpToken1).safeApprove(unirouter, type(uint256).max);
 
         if (rewardToOutputRoute[0] != nullAddress) {
-                IERC20(rewardToOutputRoute[0]).safeApprove(unirouter, 0);
-                IERC20(rewardToOutputRoute[0]).safeApprove(unirouter, uint256(-1));
+            IERC20(rewardToOutputRoute[0]).safeApprove(unirouter, 0);
+            IERC20(rewardToOutputRoute[0]).safeApprove(unirouter, uint256(-1));
         }
     }
 
@@ -318,7 +318,7 @@ contract StrategyPangolinMiniChefLP is StratManager, FeeManager {
         IERC20(_rewardToOutputRoute[0]).safeApprove(unirouter, uint256(-1));
     }
 
-    function removeRewardRoute() external onlyOwner {
+    function removeRewardRoute() external onlyManager {
         address reward = rewardToOutputRoute[0];
         if (reward != lpToken0 && reward != lpToken1 && reward != nullAddress) {
             IERC20(reward).safeApprove(unirouter, 0);

--- a/contracts/BIFI/strategies/Pangolin/StrategyPangolinMiniChefLP.sol
+++ b/contracts/BIFI/strategies/Pangolin/StrategyPangolinMiniChefLP.sol
@@ -146,7 +146,16 @@ contract StrategyPangolinMiniChefLP is StratManager, FeeManager {
     // compounds earnings and charges performance fee
     function _harvest(address callFeeRecipient) internal whenNotPaused {
         IPangolinMiniChef(chef).harvest(poolId, address(this));
+        if (rewardToOutputRoute[0] != nullAddress) {
+                address reward = rewardToOutputRoute[0];
+                uint256 rewardBal = IERC20(reward).balanceOf(address(this));
+                if (rewardBal > 0) {
+                    IUniswapRouterETH(unirouter).swapExactTokensForTokens(rewardBal, 0, rewardToOutputRoute, address(this), now);
+                }
+        }
+
         uint256 outputBal = IERC20(output).balanceOf(address(this));
+
         if (outputBal > 0) {
             chargeFees(callFeeRecipient);
             addLiquidity();
@@ -160,14 +169,6 @@ contract StrategyPangolinMiniChefLP is StratManager, FeeManager {
 
     // performance fees
     function chargeFees(address callFeeRecipient) internal {
-        if (rewardToOutputRoute[0] != nullAddress) {
-                address reward = rewardToOutputRoute[0];
-                uint256 rewardBal = IERC20(reward).balanceOf(address(this));
-                if (rewardBal > 0) {
-                    IUniswapRouterETH(unirouter).swapExactTokensForTokens(rewardBal, 0, rewardToOutputRoute, address(this), now);
-                }
-        }
-        
         uint256 toNative = IERC20(output).balanceOf(address(this)).mul(45).div(1000);
         IUniswapRouterETH(unirouter).swapExactTokensForTokens(toNative, 0, outputToNativeRoute, address(this), now);
 


### PR DESCRIPTION
As per the discussion on discord, I've ammended the PangolinV2 contract with the following changes:

- Rename the harestWithCallFeeRecipient function to the latest convention.
- Add support for a optional second reward token route which can be set either at the time of deployment or at a later date without requiring the strategy contracts to be completely redeployed.