### PR TITLE
Update StrategyTraderJoeDualLP to swap all native AVAX

### DIFF
--- a/contracts/BIFI/strategies/TraderJoe/StrategyTraderJoeDualLP.sol
+++ b/contracts/BIFI/strategies/TraderJoe/StrategyTraderJoeDualLP.sol
@@ -84,7 +84,7 @@ contract StrategyTraderJoeDualLP is StratManager, FeeManager {
 
         if (wantBal > 0) {
             IMasterChef(chef).deposit(poolId, wantBal);
-            uint256 _toWrap = msg.value;
+            uint256 _toWrap = address(this).balance;
             IWrappedNative(native).deposit{value: _toWrap}();
             emit Deposit(balanceOf());
         }
@@ -97,7 +97,7 @@ contract StrategyTraderJoeDualLP is StratManager, FeeManager {
 
         if (wantBal < _amount) {
             IMasterChef(chef).withdraw(poolId, _amount.sub(wantBal));
-            uint256 _toWrap = msg.value;
+            uint256 _toWrap = address(this).balance;
             IWrappedNative(native).deposit{value: _toWrap}();
             wantBal = IERC20(want).balanceOf(address(this));
         }
@@ -138,7 +138,7 @@ contract StrategyTraderJoeDualLP is StratManager, FeeManager {
     // compounds earnings and charges performance fee
     function _harvest(address callFeeRecipient) internal {
         IMasterChef(chef).deposit(poolId, 0);
-        uint256 _toWrap = msg.value;
+        uint256 _toWrap = address(this).balance;
         IWrappedNative(native).deposit{value: _toWrap}();
         uint256 outputBal = IERC20(output).balanceOf(address(this));
         if (outputBal > 0) {


### PR DESCRIPTION
The StrategyTraderJoeDualLP has a massive flaw, where native AVAX funds are not picked up when harvesting and are therefore essentially stuck in the strategy. See the JOE-AVAX vault for example: https://snowtrace.io/address/0xD53b145739352c1BCc7079cDdA0cf6EDfbd8F015#readContract

The problem is that the strat takes the avax value of the message(transaction), which is usually 0.
Reading the native balance of the strat and using all available AVAX circumvents this problem.