### PR TITLE
Strategy for Hector TOR Curve LP

### DIFF
--- a/contracts/BIFI/interfaces/hector/IStakingRewards.sol
+++ b/contracts/BIFI/interfaces/hector/IStakingRewards.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.6.0;
+
+interface IStakingRewards {
+    function stake(uint256 amount) external;
+    function withdraw(uint256 amount) external;
+    function getReward() external;
+    function balanceOf(address account) external view returns (uint256);
+    function earned(address account) external view returns (uint256);
+}

--- a/contracts/BIFI/strategies/Curve/StrategyCurveHectorLP.sol
+++ b/contracts/BIFI/strategies/Curve/StrategyCurveHectorLP.sol
@@ -1,0 +1,299 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.6.0;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
+import "@openzeppelin/contracts/math/SafeMath.sol";
+
+import "../../interfaces/common/IUniswapRouterETH.sol";
+import "../../interfaces/common/IUniswapV2Pair.sol";
+import "../../interfaces/hector/IStakingRewards.sol";
+import "../../interfaces/curve/ICurveSwap.sol";
+import "../Common/StratManager.sol";
+import "../Common/FeeManager.sol";
+import "../../utils/StringUtils.sol";
+import "../../utils/GasThrottler.sol";
+
+contract StrategyCurveHectorLP is StratManager, FeeManager, GasThrottler {
+    using SafeERC20 for IERC20;
+    using SafeMath for uint256;
+
+    // Tokens used
+    address public native;
+    address public output;
+    address public want;
+    address public depositToken;
+
+    // Third party contracts
+    address public stakingRewards;
+    address public pool;
+    uint public poolSize;
+    uint public depositIndex;
+    bool public useMetapool;
+
+    bool public harvestOnDeposit;
+    uint256 public lastHarvest;
+
+    // Routes
+    address[] public outputToNativeRoute;
+    address[] public outputToDepositRoute;
+
+    event StratHarvest(address indexed harvester, uint256 wantHarvested, uint256 tvl);
+    event Deposit(uint256 tvl);
+    event Withdraw(uint256 tvl);
+
+    constructor(
+        address _want,
+        address _stakingRewards,
+        address _pool,
+        uint _poolSize,
+        uint _depositIndex,
+        bool _useMetapool,
+        address[] memory _outputToNativeRoute,
+        address[] memory _outputToDepositRoute,
+        address _vault,
+        address _unirouter,
+        address _keeper,
+        address _strategist,
+        address _beefyFeeRecipient
+    ) StratManager(_keeper, _strategist, _unirouter, _vault, _beefyFeeRecipient) public {
+        want = _want;
+        stakingRewards = _stakingRewards;
+        pool = _pool;
+        poolSize = _poolSize;
+        depositIndex = _depositIndex;
+        useMetapool = _useMetapool;
+
+        output = _outputToNativeRoute[0];
+        native = _outputToNativeRoute[_outputToNativeRoute.length - 1];
+        outputToNativeRoute = _outputToNativeRoute;
+
+        require(_outputToDepositRoute[0] == output, '_outputToDepositRoute[0] != output');
+        depositToken = _outputToDepositRoute[_outputToDepositRoute.length - 1];
+        outputToDepositRoute = _outputToDepositRoute;
+
+        _giveAllowances();
+    }
+
+    // puts the funds to work
+    function deposit() public whenNotPaused {
+        uint256 wantBal = IERC20(want).balanceOf(address(this));
+
+        if (wantBal > 0) {
+            IStakingRewards(stakingRewards).stake(wantBal);
+            emit Deposit(balanceOf());
+        }
+    }
+
+    function withdraw(uint256 _amount) external {
+        require(msg.sender == vault, "!vault");
+
+        uint256 wantBal = IERC20(want).balanceOf(address(this));
+
+        if (wantBal < _amount) {
+            IStakingRewards(stakingRewards).withdraw(_amount.sub(wantBal));
+            wantBal = IERC20(want).balanceOf(address(this));
+        }
+
+        if (wantBal > _amount) {
+            wantBal = _amount;
+        }
+
+        if (tx.origin != owner() && !paused()) {
+            uint256 withdrawalFeeAmount = wantBal.mul(withdrawalFee).div(WITHDRAWAL_MAX);
+            wantBal = wantBal.sub(withdrawalFeeAmount);
+        }
+
+        IERC20(want).safeTransfer(vault, wantBal);
+
+        emit Withdraw(balanceOf());
+    }
+
+    function beforeDeposit() external override {
+        if (harvestOnDeposit) {
+            require(msg.sender == vault, "!vault");
+            _harvest(tx.origin);
+        }
+    }
+
+    function harvest() external virtual gasThrottle {
+        _harvest(tx.origin);
+    }
+
+    function harvest(address callFeeRecipient) external virtual gasThrottle {
+        _harvest(callFeeRecipient);
+    }
+
+    function managerHarvest() external onlyManager {
+        _harvest(tx.origin);
+    }
+
+    // compounds earnings and charges performance fee
+    function _harvest(address callFeeRecipient) internal whenNotPaused {
+        IStakingRewards(stakingRewards).getReward();
+        uint256 outputBal = IERC20(output).balanceOf(address(this));
+        if (outputBal > 0) {
+            chargeFees(callFeeRecipient);
+            addLiquidity();
+            uint256 wantHarvested = balanceOfWant();
+            deposit();
+
+            lastHarvest = block.timestamp;
+            emit StratHarvest(msg.sender, wantHarvested, balanceOf());
+        }
+    }
+
+    // performance fees
+    function chargeFees(address callFeeRecipient) internal {
+        uint256 toNative = IERC20(output).balanceOf(address(this)).mul(45).div(1000);
+        uint256 nativeBal;
+
+        if (output != native) {
+            IUniswapRouterETH(unirouter).swapExactTokensForTokens(toNative, 0, outputToNativeRoute, address(this), now);
+            nativeBal = IERC20(native).balanceOf(address(this));
+        } else {
+            nativeBal = toNative;
+        }
+
+        uint256 callFeeAmount = nativeBal.mul(callFee).div(MAX_FEE);
+        IERC20(native).safeTransfer(callFeeRecipient, callFeeAmount);
+
+        uint256 beefyFeeAmount = nativeBal.mul(beefyFee).div(MAX_FEE);
+        IERC20(native).safeTransfer(beefyFeeRecipient, beefyFeeAmount);
+
+        uint256 strategistFee = nativeBal.mul(STRATEGIST_FEE).div(MAX_FEE);
+        IERC20(native).safeTransfer(strategist, strategistFee);
+    }
+
+    // Adds liquidity to AMM and gets more LP tokens.
+    function addLiquidity() internal {
+        if (depositToken != output) {
+            uint256 outputBal = IERC20(output).balanceOf(address(this));
+            IUniswapRouterETH(unirouter).swapExactTokensForTokens(outputBal, 0, outputToDepositRoute, address(this), block.timestamp);
+        }
+
+        uint256 depositBal = IERC20(depositToken).balanceOf(address(this));
+
+        if (poolSize == 2) {
+            uint256[2] memory amounts;
+            amounts[depositIndex] = depositBal;
+            ICurveSwap2(pool).add_liquidity(amounts, 0);
+        } else if (poolSize == 3) {
+            uint256[3] memory amounts;
+            amounts[depositIndex] = depositBal;
+            if (useMetapool) ICurveSwap3(pool).add_liquidity(want, amounts, 0);
+            else ICurveSwap3(pool).add_liquidity(amounts, 0);
+        } else if (poolSize == 4) {
+            uint256[4] memory amounts;
+            amounts[depositIndex] = depositBal;
+            if (useMetapool) ICurveSwap4(pool).add_liquidity(want, amounts, 0);
+            else ICurveSwap4(pool).add_liquidity(amounts, 0);
+        } else if (poolSize == 5) {
+            uint256[5] memory amounts;
+            amounts[depositIndex] = depositBal;
+            ICurveSwap5(pool).add_liquidity(amounts, 0);
+        }
+    }
+
+    // calculate the total underlaying 'want' held by the strat.
+    function balanceOf() public view returns (uint256) {
+        return balanceOfWant().add(balanceOfPool());
+    }
+
+    // it calculates how much 'want' this contract holds.
+    function balanceOfWant() public view returns (uint256) {
+        return IERC20(want).balanceOf(address(this));
+    }
+
+    // it calculates how much 'want' the strategy has working in the farm.
+    function balanceOfPool() public view returns (uint256) {
+        return IStakingRewards(stakingRewards).balanceOf(address(this));
+    }
+
+    function rewardsAvailable() public view returns (uint256) {
+        return IStakingRewards(stakingRewards).earned(address(this));
+    }
+
+    // native reward amount for calling harvest
+    function callReward() public view returns (uint256) {
+        uint256 outputBal = rewardsAvailable();
+        uint256 nativeOut;
+        if (output == native) {
+            nativeOut = outputBal;
+        } else if (outputBal > 0) {
+            try IUniswapRouterETH(unirouter).getAmountsOut(outputBal, outputToNativeRoute)
+                returns (uint256[] memory amountOut) 
+            {
+                nativeOut = amountOut[amountOut.length -1];
+            }
+            catch {}
+        }
+
+        return nativeOut.mul(45).div(1000).mul(callFee).div(MAX_FEE);
+    }
+
+    function setShouldGasThrottle(bool _shouldGasThrottle) external onlyManager {
+        shouldGasThrottle = _shouldGasThrottle;
+    }
+
+    function setHarvestOnDeposit(bool _harvestOnDeposit) external onlyManager {
+        harvestOnDeposit = _harvestOnDeposit;
+
+        if (harvestOnDeposit) {
+            setWithdrawalFee(0);
+        } else {
+            setWithdrawalFee(10);
+        }
+    }
+
+    // called as part of strat migration. Sends all the available funds back to the vault.
+    function retireStrat() external {
+        require(msg.sender == vault, "!vault");
+
+        IStakingRewards(stakingRewards).withdraw(balanceOfPool());
+
+        uint256 wantBal = IERC20(want).balanceOf(address(this));
+        IERC20(want).transfer(vault, wantBal);
+    }
+
+    // pauses deposits and withdraws all funds from third party systems.
+    function panic() public onlyManager {
+        pause();
+        IStakingRewards(stakingRewards).withdraw(balanceOfPool());
+    }
+
+    function pause() public onlyManager {
+        _pause();
+
+        _removeAllowances();
+    }
+
+    function unpause() external onlyManager {
+        _unpause();
+
+        _giveAllowances();
+
+        deposit();
+    }
+
+    function _giveAllowances() internal {
+        IERC20(want).safeApprove(stakingRewards, type(uint).max);
+        IERC20(output).safeApprove(unirouter, type(uint).max);
+        IERC20(depositToken).safeApprove(pool, type(uint).max);
+    }
+
+    function _removeAllowances() internal {
+        IERC20(want).safeApprove(stakingRewards, 0);
+        IERC20(output).safeApprove(unirouter, 0);
+        IERC20(depositToken).safeApprove(pool, 0);
+    }
+
+    function outputToNative() external view returns (address[] memory) {
+        return outputToNativeRoute;
+    }
+
+    function outputToDeposit() external view returns (address[] memory) {
+        return outputToDepositRoute;
+    }
+}


### PR DESCRIPTION
Strategy is based on `StrategyChefCurveLP` ([diff](https://www.diffchecker.com/ZugLdxGa)), replacing the `IMasterChef` contract with `IStakingRewards`, and changing deposit/withdraw/harvest calls accordingly. 

Additionally, because the only pool that will be using this strategy currently pays rewards in WFTM (i.e. `output == native`), I added a special case to avoid swapping `output` to `native` in that situation, but without losing the ability to potentially use this contract for other pools that may use a different reward token. 

It might make sense to rename this contract `StrategyCurveStakingRewardsLP`.