### PR TITLE
Excalibur Common Chef Strats

### DIFF
--- a/contracts/BIFI/interfaces/excalibur/IExcaliburRouter.sol
+++ b/contracts/BIFI/interfaces/excalibur/IExcaliburRouter.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity >=0.6.2;
 
 interface IUniswapV2Router01 {
@@ -87,6 +88,7 @@ interface IUniswapV2Router01 {
 
   function getAmountOut(uint amountIn, uint reserveIn, uint reserveOut, uint feeAmount) external pure returns (uint amountOut);
   function getAmountIn(uint amountOut, uint reserveIn, uint reserveOut, uint feeAmount) external pure returns (uint amountIn);
+  function getAmountsOut(uint amountIn, address[] calldata path) external view returns (uint[] memory amounts);
 }
 
 interface IExcaliburRouter is IUniswapV2Router01 {

--- a/contracts/BIFI/interfaces/excalibur/IExcaliburRouterETH.sol
+++ b/contracts/BIFI/interfaces/excalibur/IExcaliburRouterETH.sol
@@ -1,0 +1,139 @@
+pragma solidity >=0.6.2;
+
+interface IUniswapV2Router01 {
+  function factory() external pure returns (address);
+
+  function WETH() external pure returns (address);
+
+  function addLiquidity(
+    address tokenA,
+    address tokenB,
+    uint amountADesired,
+    uint amountBDesired,
+    uint amountAMin,
+    uint amountBMin,
+    address to,
+    uint deadline
+  ) external returns (uint amountA, uint amountB, uint liquidity);
+
+  function addLiquidityETH(
+    address token,
+    uint amountTokenDesired,
+    uint amountTokenMin,
+    uint amountETHMin,
+    address to,
+    uint deadline
+  ) external payable returns (uint amountToken, uint amountETH, uint liquidity);
+
+  function removeLiquidity(
+    address tokenA,
+    address tokenB,
+    uint liquidity,
+    uint amountAMin,
+    uint amountBMin,
+    address to,
+    uint deadline
+  ) external returns (uint amountA, uint amountB);
+
+  function removeLiquidityETH(
+    address token,
+    uint liquidity,
+    uint amountTokenMin,
+    uint amountETHMin,
+    address to,
+    uint deadline
+  ) external returns (uint amountToken, uint amountETH);
+
+  function removeLiquidityWithPermit(
+    address tokenA,
+    address tokenB,
+    uint liquidity,
+    uint amountAMin,
+    uint amountBMin,
+    address to,
+    uint deadline,
+    bool approveMax, uint8 v, bytes32 r, bytes32 s
+  ) external returns (uint amountA, uint amountB);
+
+  function removeLiquidityETHWithPermit(
+    address token,
+    uint liquidity,
+    uint amountTokenMin,
+    uint amountETHMin,
+    address to,
+    uint deadline,
+    bool approveMax, uint8 v, bytes32 r, bytes32 s
+  ) external returns (uint amountToken, uint amountETH);
+
+  function swapTokensForExactTokens(
+    uint amountOut,
+    uint amountInMax,
+    address[] calldata path,
+    address to,
+    address referrer,
+    uint deadline
+  ) external returns (uint[] memory amounts);
+
+  function swapTokensForExactETH(uint amountOut, uint amountInMax, address[] calldata path, address to, address referrer, uint deadline)
+  external
+  returns (uint[] memory amounts);
+
+  function swapETHForExactTokens(uint amountOut, address[] calldata path, address to, address referrer, uint deadline)
+  external
+  payable
+  returns (uint[] memory amounts);
+
+  function quote(uint amountA, uint reserveA, uint reserveB) external pure returns (uint amountB);
+
+  function getAmountOut(uint amountIn, uint reserveIn, uint reserveOut, uint feeAmount) external pure returns (uint amountOut);
+  function getAmountIn(uint amountOut, uint reserveIn, uint reserveOut, uint feeAmount) external pure returns (uint amountIn);
+}
+
+interface IExcaliburRouter is IUniswapV2Router01 {
+  function removeLiquidityETHSupportingFeeOnTransferTokens(
+    address token,
+    uint liquidity,
+    uint amountTokenMin,
+    uint amountETHMin,
+    address to,
+    uint deadline
+  ) external returns (uint amountETH);
+
+  function removeLiquidityETHWithPermitSupportingFeeOnTransferTokens(
+    address token,
+    uint liquidity,
+    uint amountTokenMin,
+    uint amountETHMin,
+    address to,
+    uint deadline,
+    bool approveMax, uint8 v, bytes32 r, bytes32 s
+  ) external returns (uint amountETH);
+
+  function swapExactTokensForTokensSupportingFeeOnTransferTokens(
+    uint amountIn,
+    uint amountOutMin,
+    address[] calldata path,
+    address to,
+    address referrer,
+    uint deadline
+  ) external;
+
+  function swapExactETHForTokensSupportingFeeOnTransferTokens(
+    uint amountOutMin,
+    address[] calldata path,
+    address to,
+    address referrer,
+    uint deadline
+  ) external payable;
+
+  function swapExactTokensForETHSupportingFeeOnTransferTokens(
+    uint amountIn,
+    uint amountOutMin,
+    address[] calldata path,
+    address to,
+    address referrer,
+    uint deadline
+  ) external;
+
+
+}

--- a/contracts/BIFI/interfaces/excalibur/IGrailToken.sol
+++ b/contracts/BIFI/interfaces/excalibur/IGrailToken.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.6.2;
+
+interface IGrailToken {
+
+  function unwrap(uint256 amount) external;
+  function getExpectedUnwrappedTokenAmount(address account, uint256 amount) external view returns (uint256);
+}

--- a/contracts/BIFI/strategies/Excalibur/StrategyExcaliburCommonChefLP.sol
+++ b/contracts/BIFI/strategies/Excalibur/StrategyExcaliburCommonChefLP.sol
@@ -1,0 +1,304 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.6.0;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
+import "@openzeppelin/contracts/math/SafeMath.sol";
+
+import "../../interfaces/excalibur/IExcaliburRouterETH.sol";
+import "../../interfaces/common/IUniswapV2Pair.sol";
+import "../../interfaces/common/IMasterChef.sol";
+import "../Common/StratManager.sol";
+import "../Common/FeeManager.sol";
+import "../../utils/StringUtils.sol";
+import "../../utils/GasThrottler.sol";
+
+contract StrategyCommonChefLP is StratManager, FeeManager, GasThrottler {
+    using SafeERC20 for IERC20;
+    using SafeMath for uint256;
+
+    // Tokens used
+    address public native;
+    address public output;
+    address public want;
+    address public lpToken0;
+    address public lpToken1;
+
+    // Third party contracts
+    address public chef;
+    uint256 public poolId;
+
+    bool public harvestOnDeposit;
+    uint256 public lastHarvest;
+    string public pendingRewardsFunctionName;
+
+    // Routes
+    address[] public outputToNativeRoute;
+    address[] public outputToLp0Route;
+    address[] public outputToLp1Route;
+
+    event StratHarvest(address indexed harvester, uint256 wantHarvested, uint256 tvl);
+    event Deposit(uint256 tvl);
+    event Withdraw(uint256 tvl);
+    event ChargedFees(uint256 callFees, uint256 beefyFees, uint256 strategistFees);
+
+    constructor(
+        address _want,
+        uint256 _poolId,
+        address _chef,
+        address _vault,
+        address _unirouter,
+        address _keeper,
+        address _strategist,
+        address _beefyFeeRecipient,
+        address[] memory _outputToNativeRoute,
+        address[] memory _outputToLp0Route,
+        address[] memory _outputToLp1Route
+    ) StratManager(_keeper, _strategist, _unirouter, _vault, _beefyFeeRecipient) public {
+        want = _want;
+        poolId = _poolId;
+        chef = _chef;
+
+        output = _outputToNativeRoute[0];
+        native = _outputToNativeRoute[_outputToNativeRoute.length - 1];
+        outputToNativeRoute = _outputToNativeRoute;
+
+        // setup lp routing
+        lpToken0 = IUniswapV2Pair(want).token0();
+        require(_outputToLp0Route[0] == output, "outputToLp0Route[0] != output");
+        require(_outputToLp0Route[_outputToLp0Route.length - 1] == lpToken0, "outputToLp0Route[last] != lpToken0");
+        outputToLp0Route = _outputToLp0Route;
+
+        lpToken1 = IUniswapV2Pair(want).token1();
+        require(_outputToLp1Route[0] == output, "outputToLp1Route[0] != output");
+        require(_outputToLp1Route[_outputToLp1Route.length - 1] == lpToken1, "outputToLp1Route[last] != lpToken1");
+        outputToLp1Route = _outputToLp1Route;
+
+        _giveAllowances();
+    }
+
+    // puts the funds to work
+    function deposit() public whenNotPaused {
+        uint256 wantBal = IERC20(want).balanceOf(address(this));
+
+        if (wantBal > 0) {
+            IMasterChef(chef).deposit(poolId, wantBal);
+            emit Deposit(balanceOf());
+        }
+    }
+
+    function withdraw(uint256 _amount) external {
+        require(msg.sender == vault, "!vault");
+
+        uint256 wantBal = IERC20(want).balanceOf(address(this));
+
+        if (wantBal < _amount) {
+            IMasterChef(chef).withdraw(poolId, _amount.sub(wantBal));
+            wantBal = IERC20(want).balanceOf(address(this));
+        }
+
+        if (wantBal > _amount) {
+            wantBal = _amount;
+        }
+
+        if (tx.origin != owner() && !paused()) {
+            uint256 withdrawalFeeAmount = wantBal.mul(withdrawalFee).div(WITHDRAWAL_MAX);
+            wantBal = wantBal.sub(withdrawalFeeAmount);
+        }
+
+        IERC20(want).safeTransfer(vault, wantBal);
+
+        emit Withdraw(balanceOf());
+    }
+
+    function beforeDeposit() external override {
+        if (harvestOnDeposit) {
+            require(msg.sender == vault, "!vault");
+            _harvest(tx.origin);
+        }
+    }
+
+    function harvest() external gasThrottle virtual {
+        _harvest(tx.origin);
+    }
+
+    function harvest(address callFeeRecipient) external gasThrottle virtual {
+        _harvest(callFeeRecipient);
+    }
+
+    function managerHarvest() external onlyManager {
+        _harvest(tx.origin);
+    }
+
+    // compounds earnings and charges performance fee
+    function _harvest(address callFeeRecipient) internal whenNotPaused {
+        IMasterChef(chef).deposit(poolId, 0);
+        uint256 outputBal = IERC20(output).balanceOf(address(this));
+        if (outputBal > 0) {
+            chargeFees(callFeeRecipient);
+            addLiquidity();
+            uint256 wantHarvested = balanceOfWant();
+            deposit();
+
+            lastHarvest = block.timestamp;
+            emit StratHarvest(msg.sender, wantHarvested, balanceOf());
+        }
+    }
+
+    // performance fees
+    function chargeFees(address callFeeRecipient) internal {
+        uint256 toNative = IERC20(output).balanceOf(address(this)).mul(45).div(1000);
+        IExcaliburRouterETH(unirouter).swapExactTokensForTokensSupportingFeeOnTransferTokens(toNative, 0, outputToNativeRoute, address(this), beefyFeeRecipient, now);
+
+        uint256 nativeBal = IERC20(native).balanceOf(address(this));
+
+        uint256 callFeeAmount = nativeBal.mul(callFee).div(MAX_FEE);
+        IERC20(native).safeTransfer(callFeeRecipient, callFeeAmount);
+
+        uint256 beefyFeeAmount = nativeBal.mul(beefyFee).div(MAX_FEE);
+        IERC20(native).safeTransfer(beefyFeeRecipient, beefyFeeAmount);
+
+        uint256 strategistFeeAmount = nativeBal.mul(STRATEGIST_FEE).div(MAX_FEE);
+        IERC20(native).safeTransfer(strategist, strategistFeeAmount);
+
+        emit ChargedFees(callFeeAmount, beefyFeeAmount, strategistFeeAmount);
+    }
+
+    // Adds liquidity to AMM and gets more LP tokens.
+    function addLiquidity() internal {
+        uint256 outputHalf = IERC20(output).balanceOf(address(this)).div(2);
+
+        if (lpToken0 != output) {
+            IExcaliburRouterETH(unirouter).swapExactTokensForTokensSupportingFeeOnTransferTokens(outputHalf, 0, outputToLp0Route, address(this), beefyFeeRecipient, now);
+        }
+
+        if (lpToken1 != output) {
+            IExcaliburRouterETH(unirouter).swapExactTokensForTokensSupportingFeeOnTransferTokens(outputHalf, 0, outputToLp1Route, address(this), beefyFeeRecipient, now);
+        }
+
+        uint256 lp0Bal = IERC20(lpToken0).balanceOf(address(this));
+        uint256 lp1Bal = IERC20(lpToken1).balanceOf(address(this));
+        IExcaliburRouterETH(unirouter).addLiquidity(lpToken0, lpToken1, lp0Bal, lp1Bal, 1, 1, address(this), now);
+    }
+
+    // calculate the total underlaying 'want' held by the strat.
+    function balanceOf() public view returns (uint256) {
+        return balanceOfWant().add(balanceOfPool());
+    }
+
+    // it calculates how much 'want' this contract holds.
+    function balanceOfWant() public view returns (uint256) {
+        return IERC20(want).balanceOf(address(this));
+    }
+
+    // it calculates how much 'want' the strategy has working in the farm.
+    function balanceOfPool() public view returns (uint256) {
+        (uint256 _amount,) = IMasterChef(chef).userInfo(poolId, address(this));
+        return _amount;
+    }
+
+    function setPendingRewardsFunctionName(string calldata _pendingRewardsFunctionName) external onlyManager {
+        pendingRewardsFunctionName = _pendingRewardsFunctionName;
+    }
+
+    // returns rewards unharvested
+    function rewardsAvailable() public view returns (uint256) {
+        string memory signature = StringUtils.concat(pendingRewardsFunctionName, "(uint256,address)");
+        bytes memory result = Address.functionStaticCall(
+            chef, 
+            abi.encodeWithSignature(
+                signature,
+                poolId,
+                address(this)
+            )
+        );  
+        return abi.decode(result, (uint256));
+    }
+
+    // native reward amount for calling harvest
+    function callReward() public view returns (uint256) {
+        uint256 outputBal = rewardsAvailable();
+        uint256 nativeOut;
+        if (outputBal > 0) {
+            uint256[] memory amountOut = IExcaliburRouterETH(unirouter).getAmountsOut(outputBal, outputToNativeRoute);
+            nativeOut = amountOut[amountOut.length -1];
+        }
+
+        return nativeOut.mul(45).div(1000).mul(callFee).div(MAX_FEE);
+    }
+
+    function setHarvestOnDeposit(bool _harvestOnDeposit) external onlyManager {
+        harvestOnDeposit = _harvestOnDeposit;
+
+        if (harvestOnDeposit) {
+            setWithdrawalFee(0);
+        } else {
+            setWithdrawalFee(10);
+        }
+    }
+
+    function setShouldGasThrottle(bool _shouldGasThrottle) external onlyManager {
+        shouldGasThrottle = _shouldGasThrottle;
+    }
+
+    // called as part of strat migration. Sends all the available funds back to the vault.
+    function retireStrat() external {
+        require(msg.sender == vault, "!vault");
+
+        IMasterChef(chef).emergencyWithdraw(poolId);
+
+        uint256 wantBal = IERC20(want).balanceOf(address(this));
+        IERC20(want).transfer(vault, wantBal);
+    }
+
+    // pauses deposits and withdraws all funds from third party systems.
+    function panic() public onlyManager {
+        pause();
+        IMasterChef(chef).emergencyWithdraw(poolId);
+    }
+
+    function pause() public onlyManager {
+        _pause();
+
+        _removeAllowances();
+    }
+
+    function unpause() external onlyManager {
+        _unpause();
+
+        _giveAllowances();
+
+        deposit();
+    }
+
+    function _giveAllowances() internal {
+        IERC20(want).safeApprove(chef, uint256(-1));
+        IERC20(output).safeApprove(unirouter, uint256(-1));
+
+        IERC20(lpToken0).safeApprove(unirouter, 0);
+        IERC20(lpToken0).safeApprove(unirouter, uint256(-1));
+
+        IERC20(lpToken1).safeApprove(unirouter, 0);
+        IERC20(lpToken1).safeApprove(unirouter, uint256(-1));
+    }
+
+    function _removeAllowances() internal {
+        IERC20(want).safeApprove(chef, 0);
+        IERC20(output).safeApprove(unirouter, 0);
+        IERC20(lpToken0).safeApprove(unirouter, 0);
+        IERC20(lpToken1).safeApprove(unirouter, 0);
+    }
+
+    function outputToNative() external view returns (address[] memory) {
+        return outputToNativeRoute;
+    }
+
+    function outputToLp0() external view returns (address[] memory) {
+        return outputToLp0Route;
+    }
+
+    function outputToLp1() external view returns (address[] memory) {
+        return outputToLp1Route;
+    }
+}

--- a/contracts/BIFI/strategies/Excalibur/StrategyExcaliburCommonChefLP.sol
+++ b/contracts/BIFI/strategies/Excalibur/StrategyExcaliburCommonChefLP.sol
@@ -6,7 +6,7 @@ import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
 import "@openzeppelin/contracts/math/SafeMath.sol";
 
-import "../../interfaces/excalibur/IExcaliburRouterETH.sol";
+import "../../interfaces/excalibur/IExcaliburRouter.sol";
 import "../../interfaces/common/IUniswapV2Pair.sol";
 import "../../interfaces/common/IMasterChef.sol";
 import "../Common/StratManager.sol";
@@ -14,7 +14,7 @@ import "../Common/FeeManager.sol";
 import "../../utils/StringUtils.sol";
 import "../../utils/GasThrottler.sol";
 
-contract StrategyCommonChefLP is StratManager, FeeManager, GasThrottler {
+contract StrategyExcaliburCommonChefLP is StratManager, FeeManager, GasThrottler {
     using SafeERC20 for IERC20;
     using SafeMath for uint256;
 
@@ -149,7 +149,7 @@ contract StrategyCommonChefLP is StratManager, FeeManager, GasThrottler {
     // performance fees
     function chargeFees(address callFeeRecipient) internal {
         uint256 toNative = IERC20(output).balanceOf(address(this)).mul(45).div(1000);
-        IExcaliburRouterETH(unirouter).swapExactTokensForTokensSupportingFeeOnTransferTokens(toNative, 0, outputToNativeRoute, address(this), beefyFeeRecipient, now);
+        IExcaliburRouter(unirouter).swapExactTokensForTokensSupportingFeeOnTransferTokens(toNative, 0, outputToNativeRoute, address(this), address(this), now);
 
         uint256 nativeBal = IERC20(native).balanceOf(address(this));
 
@@ -170,16 +170,16 @@ contract StrategyCommonChefLP is StratManager, FeeManager, GasThrottler {
         uint256 outputHalf = IERC20(output).balanceOf(address(this)).div(2);
 
         if (lpToken0 != output) {
-            IExcaliburRouterETH(unirouter).swapExactTokensForTokensSupportingFeeOnTransferTokens(outputHalf, 0, outputToLp0Route, address(this), beefyFeeRecipient, now);
+            IExcaliburRouter(unirouter).swapExactTokensForTokensSupportingFeeOnTransferTokens(outputHalf, 0, outputToLp0Route, address(this), address(this), now);
         }
 
         if (lpToken1 != output) {
-            IExcaliburRouterETH(unirouter).swapExactTokensForTokensSupportingFeeOnTransferTokens(outputHalf, 0, outputToLp1Route, address(this), beefyFeeRecipient, now);
+            IExcaliburRouter(unirouter).swapExactTokensForTokensSupportingFeeOnTransferTokens(outputHalf, 0, outputToLp1Route, address(this), address(this), now);
         }
 
         uint256 lp0Bal = IERC20(lpToken0).balanceOf(address(this));
         uint256 lp1Bal = IERC20(lpToken1).balanceOf(address(this));
-        IExcaliburRouterETH(unirouter).addLiquidity(lpToken0, lpToken1, lp0Bal, lp1Bal, 1, 1, address(this), now);
+        IExcaliburRouter(unirouter).addLiquidity(lpToken0, lpToken1, lp0Bal, lp1Bal, 1, 1, address(this), now);
     }
 
     // calculate the total underlaying 'want' held by the strat.
@@ -221,7 +221,7 @@ contract StrategyCommonChefLP is StratManager, FeeManager, GasThrottler {
         uint256 outputBal = rewardsAvailable();
         uint256 nativeOut;
         if (outputBal > 0) {
-            uint256[] memory amountOut = IExcaliburRouterETH(unirouter).getAmountsOut(outputBal, outputToNativeRoute);
+            uint256[] memory amountOut = IExcaliburRouter(unirouter).getAmountsOut(outputBal, outputToNativeRoute);
             nativeOut = amountOut[amountOut.length -1];
         }
 

--- a/contracts/BIFI/strategies/Excalibur/StrategyExcaliburCommonChefLPGrail.sol
+++ b/contracts/BIFI/strategies/Excalibur/StrategyExcaliburCommonChefLPGrail.sol
@@ -1,0 +1,309 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.6.0;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
+import "@openzeppelin/contracts/math/SafeMath.sol";
+
+import "../../interfaces/excalibur/IExcaliburRouter.sol";
+import "../../interfaces/excalibur/IGrailToken.sol";
+import "../../interfaces/common/IUniswapV2Pair.sol";
+import "../../interfaces/common/IMasterChef.sol";
+import "../Common/StratManager.sol";
+import "../Common/FeeManager.sol";
+import "../../utils/StringUtils.sol";
+import "../../utils/GasThrottler.sol";
+
+contract StrategyExcaliburCommonChefLPGrail is StratManager, FeeManager, GasThrottler {
+    using SafeERC20 for IERC20;
+    using SafeMath for uint256;
+
+    // Tokens used
+    address public native;
+    address public output;
+    address public want;
+    address public lpToken0;
+    address public lpToken1;
+    address public grail = 0x1a8fd04b7eBEB82605829EEA91324D81b41d6dcf;
+
+    // Third party contracts
+    address public chef;
+    uint256 public poolId;
+
+    bool public harvestOnDeposit;
+    uint256 public lastHarvest;
+    string public pendingRewardsFunctionName;
+
+    // Routes
+    address[] public outputToNativeRoute;
+    address[] public outputToLp0Route;
+    address[] public outputToLp1Route;
+
+    event StratHarvest(address indexed harvester, uint256 wantHarvested, uint256 tvl);
+    event Deposit(uint256 tvl);
+    event Withdraw(uint256 tvl);
+    event ChargedFees(uint256 callFees, uint256 beefyFees, uint256 strategistFees);
+
+    constructor(
+        address _want,
+        uint256 _poolId,
+        address _chef,
+        address _vault,
+        address _unirouter,
+        address _keeper,
+        address _strategist,
+        address _beefyFeeRecipient,
+        address[] memory _outputToNativeRoute,
+        address[] memory _outputToLp0Route,
+        address[] memory _outputToLp1Route
+    ) StratManager(_keeper, _strategist, _unirouter, _vault, _beefyFeeRecipient) public {
+        want = _want;
+        poolId = _poolId;
+        chef = _chef;
+
+        output = _outputToNativeRoute[0];
+        native = _outputToNativeRoute[_outputToNativeRoute.length - 1];
+        outputToNativeRoute = _outputToNativeRoute;
+
+        // setup lp routing
+        lpToken0 = IUniswapV2Pair(want).token0();
+        require(_outputToLp0Route[0] == output, "outputToLp0Route[0] != output");
+        require(_outputToLp0Route[_outputToLp0Route.length - 1] == lpToken0, "outputToLp0Route[last] != lpToken0");
+        outputToLp0Route = _outputToLp0Route;
+
+        lpToken1 = IUniswapV2Pair(want).token1();
+        require(_outputToLp1Route[0] == output, "outputToLp1Route[0] != output");
+        require(_outputToLp1Route[_outputToLp1Route.length - 1] == lpToken1, "outputToLp1Route[last] != lpToken1");
+        outputToLp1Route = _outputToLp1Route;
+
+        _giveAllowances();
+    }
+
+    // puts the funds to work
+    function deposit() public whenNotPaused {
+        uint256 wantBal = IERC20(want).balanceOf(address(this));
+
+        if (wantBal > 0) {
+            IMasterChef(chef).deposit(poolId, wantBal);
+            emit Deposit(balanceOf());
+        }
+    }
+
+    function withdraw(uint256 _amount) external {
+        require(msg.sender == vault, "!vault");
+
+        uint256 wantBal = IERC20(want).balanceOf(address(this));
+
+        if (wantBal < _amount) {
+            IMasterChef(chef).withdraw(poolId, _amount.sub(wantBal));
+            wantBal = IERC20(want).balanceOf(address(this));
+        }
+
+        if (wantBal > _amount) {
+            wantBal = _amount;
+        }
+
+        if (tx.origin != owner() && !paused()) {
+            uint256 withdrawalFeeAmount = wantBal.mul(withdrawalFee).div(WITHDRAWAL_MAX);
+            wantBal = wantBal.sub(withdrawalFeeAmount);
+        }
+
+        IERC20(want).safeTransfer(vault, wantBal);
+
+        emit Withdraw(balanceOf());
+    }
+
+    function beforeDeposit() external override {
+        if (harvestOnDeposit) {
+            require(msg.sender == vault, "!vault");
+            _harvest(tx.origin);
+        }
+    }
+
+    function harvest() external gasThrottle virtual {
+        _harvest(tx.origin);
+    }
+
+    function harvest(address callFeeRecipient) external gasThrottle virtual {
+        _harvest(callFeeRecipient);
+    }
+
+    function managerHarvest() external onlyManager {
+        _harvest(tx.origin);
+    }
+
+    // compounds earnings and charges performance fee
+    function _harvest(address callFeeRecipient) internal whenNotPaused {
+        IMasterChef(chef).deposit(poolId, 0);
+        uint256 grailBal = IERC20(grail).balanceOf(address(this));
+        IGrailToken(grail).unwrap(grailBal);
+        uint256 outputBal = IERC20(output).balanceOf(address(this));
+        if (outputBal > 0) {
+            chargeFees(callFeeRecipient);
+            addLiquidity();
+            uint256 wantHarvested = balanceOfWant();
+            deposit();
+
+            lastHarvest = block.timestamp;
+            emit StratHarvest(msg.sender, wantHarvested, balanceOf());
+        }
+    }
+
+    // performance fees
+    function chargeFees(address callFeeRecipient) internal {
+        uint256 toNative = IERC20(output).balanceOf(address(this)).mul(45).div(1000);
+        IExcaliburRouter(unirouter).swapExactTokensForTokensSupportingFeeOnTransferTokens(toNative, 0, outputToNativeRoute, address(this), address(this), now);
+
+        uint256 nativeBal = IERC20(native).balanceOf(address(this));
+
+        uint256 callFeeAmount = nativeBal.mul(callFee).div(MAX_FEE);
+        IERC20(native).safeTransfer(callFeeRecipient, callFeeAmount);
+
+        uint256 beefyFeeAmount = nativeBal.mul(beefyFee).div(MAX_FEE);
+        IERC20(native).safeTransfer(beefyFeeRecipient, beefyFeeAmount);
+
+        uint256 strategistFeeAmount = nativeBal.mul(STRATEGIST_FEE).div(MAX_FEE);
+        IERC20(native).safeTransfer(strategist, strategistFeeAmount);
+
+        emit ChargedFees(callFeeAmount, beefyFeeAmount, strategistFeeAmount);
+    }
+
+    // Adds liquidity to AMM and gets more LP tokens.
+    function addLiquidity() internal {
+        uint256 outputHalf = IERC20(output).balanceOf(address(this)).div(2);
+
+        if (lpToken0 != output) {
+            IExcaliburRouter(unirouter).swapExactTokensForTokensSupportingFeeOnTransferTokens(outputHalf, 0, outputToLp0Route, address(this), address(this), now);
+        }
+
+        if (lpToken1 != output) {
+            IExcaliburRouter(unirouter).swapExactTokensForTokensSupportingFeeOnTransferTokens(outputHalf, 0, outputToLp1Route, address(this), address(this), now);
+        }
+
+        uint256 lp0Bal = IERC20(lpToken0).balanceOf(address(this));
+        uint256 lp1Bal = IERC20(lpToken1).balanceOf(address(this));
+        IExcaliburRouter(unirouter).addLiquidity(lpToken0, lpToken1, lp0Bal, lp1Bal, 1, 1, address(this), now);
+    }
+
+    // calculate the total underlaying 'want' held by the strat.
+    function balanceOf() public view returns (uint256) {
+        return balanceOfWant().add(balanceOfPool());
+    }
+
+    // it calculates how much 'want' this contract holds.
+    function balanceOfWant() public view returns (uint256) {
+        return IERC20(want).balanceOf(address(this));
+    }
+
+    // it calculates how much 'want' the strategy has working in the farm.
+    function balanceOfPool() public view returns (uint256) {
+        (uint256 _amount,) = IMasterChef(chef).userInfo(poolId, address(this));
+        return _amount;
+    }
+
+    function setPendingRewardsFunctionName(string calldata _pendingRewardsFunctionName) external onlyManager {
+        pendingRewardsFunctionName = _pendingRewardsFunctionName;
+    }
+
+    // returns rewards unharvested
+    function rewardsAvailable() public view returns (uint256) {
+        string memory signature = StringUtils.concat(pendingRewardsFunctionName, "(uint256,address)");
+        bytes memory result = Address.functionStaticCall(
+            chef, 
+            abi.encodeWithSignature(
+                signature,
+                poolId,
+                address(this)
+            )
+        );  
+        return abi.decode(result, (uint256));
+    }
+
+    // native reward amount for calling harvest
+    function callReward() public view returns (uint256) {
+        uint256 grailBal = rewardsAvailable();
+        uint256 outputBal = IGrailToken(grail).getExpectedUnwrappedTokenAmount(address(this),grailBal);
+        uint256 nativeOut;
+        if (outputBal > 0) {
+            uint256[] memory amountOut = IExcaliburRouter(unirouter).getAmountsOut(outputBal, outputToNativeRoute);
+            nativeOut = amountOut[amountOut.length -1];
+        }
+
+        return nativeOut.mul(45).div(1000).mul(callFee).div(MAX_FEE);
+    }
+
+    function setHarvestOnDeposit(bool _harvestOnDeposit) external onlyManager {
+        harvestOnDeposit = _harvestOnDeposit;
+
+        if (harvestOnDeposit) {
+            setWithdrawalFee(0);
+        } else {
+            setWithdrawalFee(10);
+        }
+    }
+
+    function setShouldGasThrottle(bool _shouldGasThrottle) external onlyManager {
+        shouldGasThrottle = _shouldGasThrottle;
+    }
+
+    // called as part of strat migration. Sends all the available funds back to the vault.
+    function retireStrat() external {
+        require(msg.sender == vault, "!vault");
+
+        IMasterChef(chef).emergencyWithdraw(poolId);
+
+        uint256 wantBal = IERC20(want).balanceOf(address(this));
+        IERC20(want).transfer(vault, wantBal);
+    }
+
+    // pauses deposits and withdraws all funds from third party systems.
+    function panic() public onlyManager {
+        pause();
+        IMasterChef(chef).emergencyWithdraw(poolId);
+    }
+
+    function pause() public onlyManager {
+        _pause();
+
+        _removeAllowances();
+    }
+
+    function unpause() external onlyManager {
+        _unpause();
+
+        _giveAllowances();
+
+        deposit();
+    }
+
+    function _giveAllowances() internal {
+        IERC20(want).safeApprove(chef, uint256(-1));
+        IERC20(output).safeApprove(unirouter, uint256(-1));
+
+        IERC20(lpToken0).safeApprove(unirouter, 0);
+        IERC20(lpToken0).safeApprove(unirouter, uint256(-1));
+
+        IERC20(lpToken1).safeApprove(unirouter, 0);
+        IERC20(lpToken1).safeApprove(unirouter, uint256(-1));
+    }
+
+    function _removeAllowances() internal {
+        IERC20(want).safeApprove(chef, 0);
+        IERC20(output).safeApprove(unirouter, 0);
+        IERC20(lpToken0).safeApprove(unirouter, 0);
+        IERC20(lpToken1).safeApprove(unirouter, 0);
+    }
+
+    function outputToNative() external view returns (address[] memory) {
+        return outputToNativeRoute;
+    }
+
+    function outputToLp0() external view returns (address[] memory) {
+        return outputToLp0Route;
+    }
+
+    function outputToLp1() external view returns (address[] memory) {
+        return outputToLp1Route;
+    }
+}


### PR DESCRIPTION
StrategyExcaliburCommonChefLP:
small difference to call signature of `swapExactTokensForTokens`, which is called `swapExactTokensForTokensSupportingFeeOnTransferTokens` in excaliburRouter: accepts `referrer` arg (set to strat address, but expect zero referrer reward). 
diff: commonChef vs excaliburCommonChef https://www.diffchecker.com/qLyCGHK3

StrategyExcaliburCommonChefLPGrail:
in addition to above, unwraps grail reward to exc after harvest before swapping for native. 
diff: commonChef vs excaliburCommonChefGrail https://www.diffchecker.com/1gKCMj01