### PR TITLE
added pangolin unirouter in testHelpers.js

### DIFF
--- a/utils/testHelpers.js
+++ b/utils/testHelpers.js
@@ -109,6 +109,7 @@ const getUnirouterData = address => {
   switch (address) {
     case "0xA52aBE4676dbfd04Df42eF7755F01A3c41f28D27":
     case "0x60aE616a2155Ee3d9A68541Ba4544862310933d4":
+    case "0xE54Ca86531e17Ef3616d22Ca28b0D458b6C89106":
       return {
         interface: "IUniswapRouterAVAX",
         swapSignature: "swapExactAVAXForTokens",


### PR DESCRIPTION
- added the address of pangolin.router in the testhelpers.js function so the test scripts work properly for pangolin's contracts