### PR TITLE
Add getAllFees to StratFeeManager

### DIFF
--- a/contracts/BIFI/interfaces/common/IFeeConfig.sol
+++ b/contracts/BIFI/interfaces/common/IFeeConfig.sol
@@ -12,7 +12,7 @@ interface IFeeConfig {
         bool active;
     }
     struct AllFees {
-        FeeCategory beefy;
+        FeeCategory performance;
         uint256 deposit;
         uint256 withdraw;
     }

--- a/contracts/BIFI/interfaces/common/IFeeConfig.sol
+++ b/contracts/BIFI/interfaces/common/IFeeConfig.sol
@@ -11,6 +11,11 @@ interface IFeeConfig {
         string label;
         bool active;
     }
+    struct AllFees {
+        FeeCategory beefy;
+        uint256 deposit;
+        uint256 withdraw;
+    }
     function getFees(address strategy) external view returns (FeeCategory memory);
     function stratFeeId(address strategy) external view returns (uint256);
     function setStratFeeId(uint256 feeId) external;

--- a/contracts/BIFI/strategies/Common/StratFeeManager.sol
+++ b/contracts/BIFI/strategies/Common/StratFeeManager.sol
@@ -28,7 +28,7 @@ contract StratFeeManager is Ownable, Pausable {
     uint256 constant DIVISOR = 1 ether;
     uint256 constant public WITHDRAWAL_FEE_CAP = 50;
     uint256 constant public WITHDRAWAL_MAX = 10000;
-    uint256 public withdrawalFee = 10;
+    uint256 internal withdrawalFee = 10;
 
     event SetStratFeeId(uint256 feeId);
     event SetWithdrawalFee(uint256 withdrawalFee);
@@ -57,8 +57,13 @@ contract StratFeeManager is Ownable, Pausable {
     }
 
     // fetch fees from config contract
-    function getFees() public view returns (IFeeConfig.FeeCategory memory) {
+    function getFees() internal view returns (IFeeConfig.FeeCategory memory) {
         return beefyFeeConfig.getFees(address(this));
+    }
+
+    // fetch fees from config contract and dynamic deposit/withdraw fees
+    function getAllFees() external view returns (IFeeConfig.AllFees memory) {
+        return IFeeConfig.AllFees(getFees(), depositFee(), withdrawFee());
     }
 
     function getStratFeeId() external view returns (uint256) {
@@ -112,6 +117,14 @@ contract StratFeeManager is Ownable, Pausable {
     function setBeefyFeeConfig(address _beefyFeeConfig) external onlyOwner {
         beefyFeeConfig = IFeeConfig(_beefyFeeConfig);
         emit SetBeefyFeeConfig(_beefyFeeConfig);
+    }
+
+    function depositFee() public virtual view returns (uint256) {
+        return 0;
+    }
+
+    function withdrawFee() public virtual view returns (uint256) {
+        return paused() ? 0 : withdrawalFee;
     }
 
     function beforeDeposit() external virtual {}


### PR DESCRIPTION
Add a view function to StratFeeManager to fetch both the fees charged by beefy and deposit/withdraw fees. Virtual functions are meant to be overriden to pull through additional fees charged by underlying platforms. `withdrawalFee` represents only the amount charged by Beefy whereas `withdrawFee()` represents the total fee applied.