### PR TITLE
Fix native approval issue for StrategyStellaswapMultiRewardsLP

### DIFF
--- a/contracts/BIFI/strategies/Stellaswap/StrategyStellaswapMultiRewardsLP.sol
+++ b/contracts/BIFI/strategies/Stellaswap/StrategyStellaswapMultiRewardsLP.sol
@@ -312,6 +312,7 @@ contract StrategyStellaswapMultiRewardsLP is StratFeeManager, GasFeeThrottler {
     function _removeAllowances() internal {
         IERC20(want).safeApprove(chef, 0);
         IERC20(output).safeApprove(unirouter, 0);
+        IERC20(native).safeApprove(unirouter, 0);
 
         IERC20(lpToken0).safeApprove(unirouter, 0);
         IERC20(lpToken1).safeApprove(unirouter, 0);

--- a/contracts/BIFI/strategies/Stellaswap/StrategyStellaswapMultiRewardsLP.sol
+++ b/contracts/BIFI/strategies/Stellaswap/StrategyStellaswapMultiRewardsLP.sol
@@ -293,6 +293,7 @@ contract StrategyStellaswapMultiRewardsLP is StratFeeManager, GasFeeThrottler {
     function _giveAllowances() internal {
         IERC20(want).safeApprove(chef, type(uint).max);
         IERC20(output).safeApprove(unirouter, type(uint).max);
+        IERC20(native).safeApprove(unirouter, type(uint).max);
 
         IERC20(lpToken0).safeApprove(unirouter, 0);
         IERC20(lpToken0).safeApprove(unirouter, type(uint).max);


### PR DESCRIPTION
StrategyStellaswapMultiRewardsLP has a flaw where native is not automatically approved for the unirouter. 
Usually all dual/multi reward strats should approve native by default. The reason this issue never caught attention in the past is that all previous Stellaswap farms had WGLMR as either lp0 or lp1 token. 
During testing of wstDOT-xcDOT i stumbled upon this as the strategy was not harvestable due to missing spend allowance for WGLMR.