### PR TITLE
Bugfix StrategyBalancerMultiRewardUniV2

### DIFF
--- a/contracts/BIFI/strategies/Balancer/StrategyBalancerMultiRewardChefUniV2.sol
+++ b/contracts/BIFI/strategies/Balancer/StrategyBalancerMultiRewardChefUniV2.sol
@@ -166,7 +166,7 @@ contract StrategyBalancerMultiRewardChefUniV2 is StratFeeManagerInitializable {
 
     function swapRewardsToNative() internal {
         uint256 outputBal = IERC20(output).balanceOf(address(this));
-        if (outputBal > 0) {
+        if (outputBal > 1 ether) {
             IBalancerVault.BatchSwapStep[] memory _swaps = BalancerActionsLib.buildSwapStructArray(outputToNativeRoute, outputBal);
             BalancerActionsLib.balancerSwap(unirouter, swapKind, _swaps, outputToNativeAssets, funds, int256(outputBal));
         }


### PR DESCRIPTION
Per @MirthFutures comments on beefyfinance/beefy-v2#1297, increasing minimum output limit to swap from 0 to 1 ether. This is due to historic problems with Beethovenx chef outputting dusting when output rewards are supposed to be disabled.