### PR TITLE
Update IBalancerVault.sol

### DIFF
--- a/contracts/BIFI/interfaces/beethovenx/IBalancerVault.sol
+++ b/contracts/BIFI/interfaces/beethovenx/IBalancerVault.sol
@@ -4,6 +4,10 @@ pragma solidity >=0.6.0 <0.9.0;
 pragma experimental ABIEncoderV2;
 
 interface IBalancerVault {
+    // Enum for swap kinds
+    enum SwapKind { GIVEN_IN, GIVEN_OUT }
+
+    // Structs for various functionalities
     struct SingleSwap {
         bytes32 poolId;
         SwapKind kind;
@@ -35,21 +39,20 @@ interface IBalancerVault {
         bool fromInternalBalance;
     }
 
-    enum SwapKind { GIVEN_IN, GIVEN_OUT }
-
+    // Function signatures
     function swap(
-        SingleSwap memory singleSwap,
-        FundManagement memory funds,
+        SingleSwap calldata singleSwap,
+        FundManagement calldata funds,
         uint256 limit,
         uint256 deadline
     ) external payable returns (uint256);
 
     function batchSwap(
         SwapKind kind,
-        BatchSwapStep[] memory swaps,
-        address[] memory assets,
-        FundManagement memory funds,
-        int256[] memory limits,
+        BatchSwapStep[] calldata swaps,
+        address[] calldata assets,
+        FundManagement calldata funds,
+        int256[] calldata limits,
         uint256 deadline
     ) external returns (int256[] memory assetDeltas);
 
@@ -57,28 +60,28 @@ interface IBalancerVault {
         bytes32 poolId,
         address sender,
         address recipient,
-        JoinPoolRequest memory request
+        JoinPoolRequest calldata request
     ) external;
 
-    function getPoolTokens(bytes32 poolId)
-        external
-        view
-        returns (
-            address[] memory tokens,
-            uint256[] memory balances,
-            uint256 lastChangeBlock
-        );
+    function getPoolTokens(
+        bytes32 poolId
+    ) external view returns (
+        address[] memory tokens,
+        uint256[] memory balances,
+        uint256 lastChangeBlock
+    );
 
-    function getPool(bytes32 poolId)
-        external
-        view
-        returns (address, uint8);
+    function getPool(
+        bytes32 poolId
+    ) external view returns (
+        address poolAddress,
+        uint8 poolSpecialization
+    );
 
     function flashLoan(
         address recipient,
-        address[] memory tokens,
-        uint256[] memory amounts,
-        bytes memory userData
+        address[] calldata tokens,
+        uint256[] calldata amounts,
+        bytes calldata userData
     ) external;
-    
 }


### PR DESCRIPTION
Changes made:

Parameter Types in Functions: Changed memory to calldata for array and struct parameters in external functions. This is more gas-efficient as calldata is a non-modifiable, temporary location where function arguments are stored, and it costs less gas compared to memory.

Return Type Naming: Added names (poolAddress and poolSpecialization) to the return types in getPool for clarity.

Formatting: Improved formatting for better readability, such as aligning function parameters and return statements.

Commenting: Added comments for better understanding of the code structure.

Remember that these changes are primarily stylistic and organizational; the core logic and functionality of the interface remain unchanged.