### PR TITLE
Enforce ERC4626 previews on wrapper

### DIFF
--- a/forge/test/interfaces/IStrategy.sol
+++ b/forge/test/interfaces/IStrategy.sol
@@ -16,6 +16,8 @@ interface IStrategy {
     event Unpaused(address account);
     event Withdraw(uint256 tvl);
 
+    error StrategyPaused();
+
     // All strats
 
     function MAX_CALL_FEE() external view returns (uint256);

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "abi-to-sol": "abi-to-sol",
     "installForge": ". scripts/forge/installForge.sh",
     "forgeTest:vault": "forge test --force --fork-url http://localhost:8545 --match-contract ProdVaultTest",
-    "forgeTest:wrapper": "forge test --force --fork-url https://arb1.arbitrum.io/rpc --match-contract WrapperTest",
+    "forgeTest:wrapper": "forge test --force --fork-url https://sonic-rpc.publicnode.com --match-contract WrapperTest",
     "forgeTest:oracle": "forge test --force --fork-url https://polygon-rpc.com --match-contract Oracle",
     "forgeTest:swapper": "forge test --force --fork-url https://polygon-rpc.com --match-contract Swapper",
     "forgeTest:aura": "forge test --force --fork-url https://rpc.ankr.com/eth --match-contract StrategyAuraGyroTest",


### PR DESCRIPTION
Switching out the conversion functions to reflect what the Beefy vault actually does and also enforce the depositing/withdrawing to always be the same as the previews. 

Wrapped vaults need to not change ppfs on deposits, i.e. excludes most HoD vaults without profit locking. That also goes for vaults like Compound which update the conversion rate on interaction with the vault.