### PR TITLE
Update Merkl claim strats to allow multiple tokens

### DIFF
--- a/contracts/BIFI/strategies/Morpho/StrategyMorpho.sol
+++ b/contracts/BIFI/strategies/Morpho/StrategyMorpho.sol
@@ -67,8 +67,10 @@ contract StrategyMorpho is BaseAllToNativeFactoryStrat {
         uint256[] calldata _amounts,
         bytes32[][] calldata _proofs
     ) external {
-        address[] memory users = new address[](1);
-        users[0] = address(this);
+		address[] memory users = new address[](_tokens.length);
+		for (uint256 i; i < _tokens.length; ++i) {
+			users[i] = address(this);
+		}
 
         claimer.claim(users, _tokens, _amounts, _proofs);
     }

--- a/contracts/BIFI/strategies/Morpho/StrategyMorphoMerkl.sol
+++ b/contracts/BIFI/strategies/Morpho/StrategyMorphoMerkl.sol
@@ -67,8 +67,10 @@ contract StrategyMorphoMerkl is BaseAllToNativeFactoryStrat {
         uint256[] calldata _amounts,
         bytes32[][] calldata _proofs
     ) external { 
-        address[] memory users = new address[](1);
-        users[0] = address(this);
+    	address[] memory users = new address[](_tokens.length);
+    	for (uint256 i; i < _tokens.length; ++i) {
+        	users[i] = address(this);
+    	}
 
         claimer.claim(users, _tokens, _amounts, _proofs);
     }

--- a/contracts/BIFI/strategies/Silo/StrategySiloVault.sol
+++ b/contracts/BIFI/strategies/Silo/StrategySiloVault.sol
@@ -121,8 +121,10 @@ contract StrategySiloVault is BaseAllToNativeFactoryStrat {
         uint256[] calldata _amounts,
         bytes32[][] calldata _proofs
     ) external { 
-        address[] memory users = new address[](1);
-        users[0] = address(this);
+		address[] memory users = new address[](_tokens.length);
+		for (uint256 i; i < _tokens.length; ++i) {
+			users[i] = address(this);
+		}
 
         claimer.claim(users, _tokens, _amounts, _proofs);
     }


### PR DESCRIPTION
Strats that implemented an `IMerklClaimer.claim()` method with an inherent `user` were hardcoded to only manage a single token. This fills in the strat address for as many token arguments as provided.