### PR TITLE
fix: revoke lpToken1 allowance in _removeAllowances()

### DIFF
--- a/contracts/BIFI/strategies/Common/StrategySolidlyRewardPool.sol
+++ b/contracts/BIFI/strategies/Common/StrategySolidlyRewardPool.sol
@@ -108,7 +108,7 @@ contract StrategySolidlyRewardPool is BaseAllToNativeFactoryStrat {
         _approve(want, address(rewardPool), 0);
         _approve(native, address(swapper), 0);
         _approve(lpToken0, address(solidlyRouter), 0);
-        _approve(lpToken0, address(solidlyRouter), 0);
+        _approve(lpToken1, address(solidlyRouter), 0);
     }
 
     function panic() public override onlyManager {

--- a/contracts/BIFI/strategies/Velodrome/StrategyVelodromeFactory.sol
+++ b/contracts/BIFI/strategies/Velodrome/StrategyVelodromeFactory.sol
@@ -108,7 +108,7 @@ contract StrategyVelodromeFactory is BaseAllToNativeFactoryStrat {
         _approve(want, address(rewardPool), 0);
         _approve(native, address(swapper), 0);
         _approve(lpToken0, address(solidlyRouter), 0);
-        _approve(lpToken0, address(solidlyRouter), 0);
+        _approve(lpToken1, address(solidlyRouter), 0);
     }
 
     function panic() public override onlyManager {


### PR DESCRIPTION
## Summary

Fixes a bug where `lpToken1` allowance is never revoked when `panic()` or `pause()` is called.

## Problem

In `StrategyVelodromeFactory` and `StrategySolidlyRewardPool`, the `_removeAllowances()` function had a duplicate line approving `lpToken0` to the solidly router, while `lpToken1` was never revoked:

```solidity
// BUG: duplicate line, lpToken1 never revoked
_approve(lpToken0, address(solidlyRouter), 0);
_approve(lpToken0, address(solidlyRouter), 0);  // Should be lpToken1
```

## Impact

When `panic()` or `pause()` is called, `lpToken1` allowances remain granted to the router. If the router is compromised or malicious, it could drain all `lpToken1` from the strategy.

## Fix

Replace duplicate `lpToken0` approval with `lpToken1`:

```solidity
_approve(lpToken0, address(solidlyRouter), 0);
_approve(lpToken1, address(solidlyRouter), 0);
```

## Files Changed

- `contracts/BIFI/strategies/Velodrome/StrategyVelodromeFactory.sol`
- `contracts/BIFI/strategies/Common/StrategySolidlyRewardPool.sol`

## Testing

- Verified that `lpToken1` is now properly revoked in both contracts
- No functional changes to deposit/withdraw/harvest flows

---

*This fix was found during a security audit by Wulansari Security Research.*