### PR TITLE
fix: add nonReentrant to BeefyVaultV7.withdraw()

### DIFF
--- a/contracts/BIFI/vaults/BeefyVaultV7.sol
+++ b/contracts/BIFI/vaults/BeefyVaultV7.sol
@@ -136,7 +136,7 @@ contract BeefyVaultV7 is ERC20Upgradeable, OwnableUpgradeable, ReentrancyGuardUp
      * from the strategy and pay up the token holder. A proportional number of IOU
      * tokens are burned in the process.
      */
-    function withdraw(uint256 _shares) public {
+    function withdraw(uint256 _shares) public nonReentrant {
         uint256 r = (balance() * _shares) / totalSupply();
         _burn(msg.sender, _shares);
 


### PR DESCRIPTION
Adds missing `nonReentrant` modifier to `BeefyVaultV7.withdraw()`.

## Problem

The `deposit()` function has `nonReentrant` but `withdraw()` does not. The `withdraw()` function makes external calls via `strategy.withdraw()` and performs a token transfer, creating a reentrancy window.

## Impact

If `strategy.withdraw()` triggers a callback (via hook or flash-loan-style callback), an attacker could re-enter `withdraw()` before the first call completes. The balance-based accounting combined with the missing reentrancy guard could allow draining vault funds.

## Fix

Add `nonReentrant` modifier to `withdraw()` to match `deposit()`.